### PR TITLE
Return if webapp is null in progressListener.onStateChange. Closes #48

### DIFF
--- a/src/content/webtab.js
+++ b/src/content/webtab.js
@@ -437,6 +437,9 @@ const webtabs = {
               return;
 
             let webapp = ConfigManager.getWebAppForURL(aTabInfo.browser.contentDocument.documentURIObject);
+            if (!webapp)
+              return;
+
             webapp.icon = icon;
             ConfigManager.persistPrefs();
 


### PR DESCRIPTION
This is a trivial fix for #48. Of course there could be better resolutions.
