### PR TITLE
fix icons not showing, Closes #63 ; add icon field and reset defaults btn; pt-BR locale;

### DIFF
--- a/src/chrome.manifest
+++ b/src/chrome.manifest
@@ -4,4 +4,5 @@
 
 content   webapptabs   content/
 locale    webapptabs   en-US         locale/en-US/
+locale    webapptabs   pt-BR         locale/pt-BR/
 skin      webapptabs   classic/1.0   skin/

--- a/src/content/config.js
+++ b/src/content/config.js
@@ -67,6 +67,12 @@ const config = {
     this.list.clearSelection();
   },
 
+  reset: function() {
+    ConfigManager.loadDefaultPrefs();
+    ConfigManager.updatePrefs();
+    this.load();
+  },
+
   input: function() {
     let enabled = document.getElementById("txt_name").value != "" &&
                   document.getElementById("txt_href").value != "";

--- a/src/content/config.js
+++ b/src/content/config.js
@@ -16,6 +16,8 @@ const config = {
   load: function() {
     this.list = document.getElementById("list_webapps");
 
+    while (this.list.itemCount > 0)
+      this.list.removeItemAt(0);
     ConfigManager.webappList.forEach(function(aDesc) {
       this.addWebAppItem(aDesc);
     }, this);
@@ -30,18 +32,26 @@ const config = {
 
   add: function() {
     let href = document.getElementById("txt_href").value;
+    let icon = document.getElementById("txt_icon").value;
+
     let URIFixup = Cc["@mozilla.org/docshell/urifixup;1"].
                    getService(Ci.nsIURIFixup);
     href = URIFixup.createFixupURI(href, Ci.nsIURIFixup.FIXUP_FLAG_NONE).spec;
+    icon = icon
+      ? URIFixup.createFixupURI(icon, Ci.nsIURIFixup.FIXUP_FLAG_NONE).spec
+      : "https://www.google.com/s2/favicons?domain=" + encodeURIComponent(href)
+      ;
 
     let desc = {
       name: document.getElementById("txt_name").value,
       href: href,
-      icon: "http://getfavicon.appspot.com/" + href
+      icon: icon
     };
 
     document.getElementById("txt_name").value = "";
     document.getElementById("txt_href").value = "";
+    document.getElementById("txt_icon").value = "";
+    this.input();
 
     ConfigManager.webappList.push(desc);
     ConfigManager.updatePrefs();
@@ -54,6 +64,7 @@ const config = {
     ConfigManager.webappList.splice(pos, 1);
     this.list.removeChild(item);
     ConfigManager.updatePrefs();
+    this.list.clearSelection();
   },
 
   input: function() {

--- a/src/content/config.xul
+++ b/src/content/config.xul
@@ -50,6 +50,7 @@
     <vbox>
       <button id="btn_add" oncommand="config.add()" label="&btn.add.label;"/>
       <button id="btn_remove" oncommand="config.remove()" label="&btn.remove.label;"/>
+      <button id="btn_reset" oncommand="config.reset()" label="&btn.reset.label;"/>
     </vbox>
   </hbox>
 </window>

--- a/src/content/config.xul
+++ b/src/content/config.xul
@@ -13,7 +13,7 @@
 <?xml-stylesheet href="chrome://webapptabs/skin/config.css"?>
 
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-        title="&title;" style="width: 400px; height: 300px;"
+        title="&title;" style="width: 640px; height: 300px;"
         onload="config.load()" onunload="config.unload()">
   <script type="text/javascript" src="config.js"/>
 
@@ -39,6 +39,10 @@
         <row>
           <label value="&lbl.href;"/>
           <textbox id="txt_href" oninput="config.input()" flex="1" placeholder="&txt.href.placeholder;"/>
+        </row>
+        <row>
+          <label value="&lbl.icon;"/>
+          <textbox id="txt_icon" oninput="config.input()" flex="1" placeholder="&txt.icon.placeholder;"/>
         </row>
       </rows>
     </grid>

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -11,7 +11,7 @@
     <em:optionsURL>chrome://webapptabs/content/config.xul</em:optionsURL>
 
     <em:name>WebApp Tabs</em:name>
-    <em:version>3.0a1</em:version>
+    <em:version>3.1a1</em:version>
     <em:creator>Dave Townsend</em:creator>
     <em:contributor>David Ascher (original code)</em:contributor>
     <em:description>Load WebApps into tabs in Thunderbird</em:description>

--- a/src/locale/en-US/config.dtd
+++ b/src/locale/en-US/config.dtd
@@ -12,3 +12,4 @@
 <!ENTITY txt.icon.placeholder    "Enter the favicon URL or leave blank to obtain automatically…">
 <!ENTITY btn.add.label           "Add">
 <!ENTITY btn.remove.label        "Remove">
+<!ENTITY btn.reset.label         "Reset to default">

--- a/src/locale/en-US/config.dtd
+++ b/src/locale/en-US/config.dtd
@@ -2,11 +2,13 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this file,
    - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
 
-<!ENTITY title                   "WebApp Tabs Options">
+<!ENTITY title                   "WebApp Tabs - Options">
 
 <!ENTITY lbl.name                "Name:">
 <!ENTITY txt.name.placeholder    "Enter the website's name…">
 <!ENTITY lbl.href                "Address:">
 <!ENTITY txt.href.placeholder    "Enter the website's address…">
+<!ENTITY lbl.icon                "Icon URL:">
+<!ENTITY txt.icon.placeholder    "Enter the favicon URL or leave blank to obtain automatically…">
 <!ENTITY btn.add.label           "Add">
 <!ENTITY btn.remove.label        "Remove">

--- a/src/locale/pt-BR/config.dtd
+++ b/src/locale/pt-BR/config.dtd
@@ -1,0 +1,15 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+
+<!ENTITY title                   "WebApp Tabs - Opções">
+
+<!ENTITY lbl.name                "Nome:">
+<!ENTITY txt.name.placeholder    "Insira o nome do website…">
+<!ENTITY lbl.href                "Endereço:">
+<!ENTITY txt.href.placeholder    "Insira o endereço do website…">
+<!ENTITY lbl.icon                "URL do Ícone:">
+<!ENTITY txt.icon.placeholder    "Insira a URL do favicon ou deixe em branco para obter automaticamente…">
+<!ENTITY btn.add.label           "Adicionar">
+<!ENTITY btn.remove.label        "Remover">
+<!ENTITY btn.reset.label         "Restaurar o padrão">

--- a/src/locale/pt-BR/webtab.dtd
+++ b/src/locale/pt-BR/webtab.dtd
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this file,
+   - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+
+<!ENTITY back.label       "Voltar">
+<!ENTITY forward.label    "Avançar">

--- a/src/modules/ConfigManager.jsm
+++ b/src/modules/ConfigManager.jsm
@@ -18,6 +18,14 @@ const EXTPREFNAME = "extensions.webapptabs.webapps";
 
 const WEBAPP_SCHEMA = 1;
 const DEFAULT_WEBAPPS = [{
+  'name': 'Outlook',
+  'href': 'https://outlook.live.com/',
+  'icon': 'https://outlook.live.com/owa/favicon.ico',
+}, {
+  'name': 'Gmail',
+  'href': 'https://mail.google.com/',
+  'icon': 'https://www.google.com/gmail/about/images/favicon.ico',
+}, {
   'name': 'Google Calendar',
   'href': 'https://calendar.google.com/',
   'icon': 'https://calendar.google.com/googlecalendar/images/favicon.ico',

--- a/src/modules/ConfigManager.jsm
+++ b/src/modules/ConfigManager.jsm
@@ -140,8 +140,11 @@ const ConfigManager = {
     catch (e) {
       ERROR("Failed to read webapps from config", e);
     }
+    this.loadDefaultPrefs();
+  },
 
-    this.webappList = DEFAULT_WEBAPPS;
+  loadDefaultPrefs: function() {
+    this.webappList = DEFAULT_WEBAPPS.slice();
     this.webappList.forEach(function(aDesc) {
       if (!aDesc.id)
         aDesc.id = aDesc.name.replace(' ', '_', 'g');


### PR DESCRIPTION
Fixes favicons not showing by using another URL to load them; the previous URL was failing (error 404).
Also allows to set a custom favicon. Gmail, for example, would have the google icon by default, because it tries to get the favicon from the login page. With this change, the user can specify it to be whatever icon they want.